### PR TITLE
Installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "write-file-webpack-plugin": "3.4.2"
   },
   "dependencies": {
-    "neon-js": "git+https://github.com/phetter/neon-js.git"
+    "neon-js": "git+https://github.com/CityOfZion/neon-js.git"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
error Couldn't find match for "084d48df5c6c1cec7dc6c6f46ee988681e5d52e1" in "_c" for "https://github.com/phetter/neon-js.git".