### PR TITLE
Add custom network Neoscan API type support

### DIFF
--- a/src/app/components/common/form/CustomNetworkForm/index.js
+++ b/src/app/components/common/form/CustomNetworkForm/index.js
@@ -11,22 +11,22 @@ const CustomNetworkForm = ({ renderTextField, renderSelectField, errors, onSubmi
     <form onSubmit={ onSubmit } className={ style.customNetworkForm }>
       <Field component={ renderTextField } type='text' name='name' label='Network Name' error={ errors.name } />
       <Field component={ renderTextField } type='text' name='url' label='Network URL' error={ errors.url } />
-      <Field component={ renderTextField } type='text' name='txUrl' label='Transaction URL' error={ errors.url } />
-      <Field
-        label='API Type'
-        component={ renderSelectField }
-        name='apiType'
-        options={ [
-          {
-            label: 'neoscan',
-            value: 'neoscan',
-          },
-          {
-            label: 'neonDB',
-            value: 'neonDB',
-          },
-        ] }
-      />
+      {/*<Field component={ renderTextField } type='text' name='txUrl' label='Transaction URL' error={ errors.url } />*/}
+      {/*<Field*/}
+        {/*label='API Type'*/}
+        {/*component={ renderSelectField }*/}
+        {/*name='apiType'*/}
+        {/*options={ [*/}
+          {/*{*/}
+            {/*label: 'neoscan',*/}
+            {/*value: 'neoscan',*/}
+          {/*},*/}
+          {/*{*/}
+            {/*label: 'neonDB',*/}
+            {/*value: 'neonDB',*/}
+          {/*},*/}
+        {/*] }*/}
+      {/*/>*/}
       <PrimaryButton buttonText='Add Network' classNames={ style.customNetworkButton } />
     </form>
   )

--- a/src/app/components/common/form/CustomNetworkForm/index.js
+++ b/src/app/components/common/form/CustomNetworkForm/index.js
@@ -11,22 +11,6 @@ const CustomNetworkForm = ({ renderTextField, renderSelectField, errors, onSubmi
     <form onSubmit={ onSubmit } className={ style.customNetworkForm }>
       <Field component={ renderTextField } type='text' name='name' label='Network Name' error={ errors.name } />
       <Field component={ renderTextField } type='text' name='url' label='Network URL' error={ errors.url } />
-      {/*<Field component={ renderTextField } type='text' name='txUrl' label='Transaction URL' error={ errors.url } />*/}
-      {/*<Field*/}
-        {/*label='API Type'*/}
-        {/*component={ renderSelectField }*/}
-        {/*name='apiType'*/}
-        {/*options={ [*/}
-          {/*{*/}
-            {/*label: 'neoscan',*/}
-            {/*value: 'neoscan',*/}
-          {/*},*/}
-          {/*{*/}
-            {/*label: 'neonDB',*/}
-            {/*value: 'neonDB',*/}
-          {/*},*/}
-        {/*] }*/}
-      {/*/>*/}
       <PrimaryButton buttonText='Add Network' classNames={ style.customNetworkButton } />
     </form>
   )

--- a/src/app/containers/AddCustomNetwork/AddCustomNetwork.js
+++ b/src/app/containers/AddCustomNetwork/AddCustomNetwork.js
@@ -55,21 +55,20 @@ export class AddCustomNetwork extends Component {
 
   handleSubmit = (values, dispatch, formProps) => {
     const { reset } = formProps
-    const { name, url, txUrl, apiType } = values
+    const { name, url } = values
     const { addCustomNetwork } = this.props
 
     const validatedName = this._validateName(name)
     const validatedUrl = this._validateUrl(url)
-    const validatedTxUrl = this._validateUrl(txUrl)
 
-    if (validatedName && validatedUrl && validatedTxUrl && apiType) {
-      addCustomNetwork(name, url, txUrl, apiType)
+    if (validatedName && validatedUrl) {
+      addCustomNetwork(name, url, 'neoscan')
 
       this.setState({
         name: '',
         url: '',
         txUrl: '',
-        apiType: '',
+        apiType: 'neoscan',
         showSuccess: true,
       })
       reset()

--- a/src/app/reducers/config.js
+++ b/src/app/reducers/config.js
@@ -1,4 +1,3 @@
-import uuidv4 from 'uuid/v4'
 
 import * as ActionTypes from '../constants/ActionTypes'
 

--- a/src/app/reducers/config.js
+++ b/src/app/reducers/config.js
@@ -48,7 +48,7 @@ const actionsMap = {
   },
   [ActionTypes.ADD_CUSTOM_NETWORK](state, action) { // TODO fix add custom network code to work with composable config
     const networks = { ...state.networks }
-    networks[uuidv4()] = {
+    networks[action.name] = {
       name: action.name,
       url: action.url,
       txUrl: action.txUrl,

--- a/src/app/utils/api/neoscan.js
+++ b/src/app/utils/api/neoscan.js
@@ -80,8 +80,6 @@ export const formatGas = gasArray => {
 
 export const switchNetwork = networkId => {
   let net
-  logDeep('Network: ', curState.config.networks)
-
   switch (networkId) {
     case 'MainNet':
       if (curState && curState.config && curState.config.neoscan) {

--- a/src/app/utils/api/neoscan.js
+++ b/src/app/utils/api/neoscan.js
@@ -7,7 +7,7 @@
 import axios from 'axios'
 
 // import { Fixed8 } from '../math'
-// import { logDeep } from '../debug'
+import { logDeep } from '../debug'
 
 import Promise from 'bluebird'
 
@@ -34,9 +34,9 @@ neoscanIni.testNet.balanceUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_
 // Store the whole thing for later management.
 neoscanIni.custom = {}
 neoscanIni.custom.rootUrl = 'https://neoscan-testnet.io/api/test_net/'
-neoscanIni.testNet.txByIdUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_transaction/'
-neoscanIni.testNet.txsByAddressUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_last_transactions_by_address/'
-neoscanIni.testNet.balanceUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_balance/'
+neoscanIni.custom.txByIdUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_transaction/'
+neoscanIni.custom.txsByAddressUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_last_transactions_by_address/'
+neoscanIni.custom.balanceUrl = 'https://neoscan-testnet.io/api/test_net/v1/get_balance/'
 
 let curState = {}
 
@@ -80,6 +80,8 @@ export const formatGas = gasArray => {
 
 export const switchNetwork = networkId => {
   let net
+  logDeep('Network: ', curState.config.networks)
+
   switch (networkId) {
     case 'MainNet':
       if (curState && curState.config && curState.config.neoscan) {
@@ -110,13 +112,33 @@ export const switchNetwork = networkId => {
       }
       break
     default:
-      // TODO need to write this case to properly handle custom networks in neoscan
-      // pseudo:
-      // loop over curState looking for a curState.config.neoscan['custom_name_literal'] that matches networkId
-      // build the json object if it isn't built.
-      // set net and active to the matched net
-      // return the net if we found one, return null if not
-      return undefined
+      if (!networkId) return undefined
+
+      if (curState && curState.config && curState.config.neoscan && curState.config.networks && curState.config.networks[networkId]) {
+        net = curState.config.neoscan.active = curState.config.networks[networkId]
+      } else {
+        // if (curState.config.neoscan[networkId].apiType !== 'neoscan') return undefined
+        console.log('networkId' + networkId)
+        let u = curState.config.neoscan[networkId].url
+        let custom = {}
+        custom.name = curState.config.neoscan[networkId].name
+        custom.rootUrl = u + '/api/test_net/'
+        custom.txByIdUrl = u + '/api/test_net/v1/get_transaction/'
+        custom.txsByAddressUrl = u + '/api/test_net/v1/get_last_transactions_by_address/'
+        custom.balanceUrl = u + '/api/test_net/v1/get_balance/'
+        custom.canDelete = true
+        custom.apiType = 'neoscan'
+        curState = {
+          config: {
+            neoscan: {
+              active: custom,
+            },
+          },
+        }
+        net = curState.config.neoscan.active
+        logDeep('net', net)
+      }
+      break
   }
   return net
 }


### PR DESCRIPTION
This adds add network support of custom networks for Neoscan. 

Neoscan is now the only supported API type.

This also fixes the custom guid name error display in custom network switcher.