### PR TITLE
chore(package): added pre commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "node utils/webserver.js",
     "test": "jest",
     "test-ci": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "prepush": "echo 'running lint...' && npm run lint && echo 'running tests...' && npm run test"
+    "precommit": "echo 'running lint...' && npm run lint",
+    "prepush": "echo 'running tests...' && npm run test"
   },
   "devDependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Split prepush commit hook into:
- precommit linting hook
- prepush testing hook

This to avoid linting issues being committed and prevent 100's of "linting fix" commits on the dev/master