### PR TITLE
feature: Updates README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently the project is undergoing heavy development.
 
 ## Setup
 
-`git clone git@github.com:CityOfZion/NeoLink.git .` 
+`git clone https://github.com/CityOfZion/NeoLink.git` 
 
 `npm install`
 


### PR DESCRIPTION
`git clone git@github.com:CityOfZion/NeoLink.git .` is not the right command to clone the repo this PR addresses the issue by adding the correct command `git clone https://github.com/CityOfZion/NeoLink.git`